### PR TITLE
Use the content media source instead of MXC URI

### DIFF
--- a/Mactrix/Views/ChatView/MessageImageView.swift
+++ b/Mactrix/Views/ChatView/MessageImageView.swift
@@ -45,14 +45,13 @@ struct MessageImageView: View {
             }
         }
         .task(id: content.source.url()) {
-            let url: String = content.source.url()
             guard let matrixClient = appState.matrixClient else {
                 errorMessage = "Matrix client not available"
                 return
             }
 
             do {
-                let data = try await matrixClient.client.getMediaContent(mediaSource: .fromUrl(url: url))
+                let data = try await matrixClient.client.getMediaContent(mediaSource: content.source)
                 imageData = data
                 let contentType = content.info?.mimetype.flatMap { UTType(mimeType: $0) }
                 image = try await Image(importing: data, contentType: contentType)


### PR DESCRIPTION
In e2ee rooms, files are encrypted with AES256-CTR and the key material is part of the timeline event content, so it's not enough to use the MXC URI to fetch the image. The Rust SDK `get_media_content` will do the decrypting for the client as long as the full media source is passed as a parameter.

So yeah, this fixes #11 🎊 