### PR TITLE
make colour-blended ui elements legible on dark mode

### DIFF
--- a/Mactrix/Views/Settings/SessionsSettingsView.swift
+++ b/Mactrix/Views/Settings/SessionsSettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct SessionsSettingsView: View {
     @Environment(AppState.self) var appState
+    @Environment(\.colorScheme) var colorScheme
 
     @ViewBuilder
     func sessionBadge(systemIcon: String, color: Color) -> some View {
@@ -10,7 +11,7 @@ struct SessionsSettingsView: View {
             .font(.system(size: 20))
             .padding(12)
             .background(RoundedRectangle(cornerRadius: 6).fill(color.opacity(0.2)))
-            .foregroundStyle(color.mix(with: .black, by: 0.2))
+            .foregroundStyle(color.mix(with: colorScheme == .light ? .black : .white, by: 0.2))
     }
 
     @ViewBuilder

--- a/Mactrix/Views/Sidebar/SidebarSessionVerification.swift
+++ b/Mactrix/Views/Sidebar/SidebarSessionVerification.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct SessionVerificationStatusView: View {
     @Environment(AppState.self) var appState
+    @Environment(\.colorScheme) var colorScheme
 
     @ViewBuilder
     var selfVerificationView: some View {
@@ -34,7 +35,7 @@ struct SessionVerificationStatusView: View {
             }
             .padding(10)
             .background(Color.red.opacity(0.2))
-            .foregroundStyle(Color.red.mix(with: .black, by: 0.5))
+            .foregroundStyle(Color.red.mix(with: colorScheme == .light ? .black : .white, by: 0.5))
             .clipShape(RoundedRectangle(cornerRadius: 8))
         }
     }

--- a/MactrixLibrary/Sources/UI/Timeline/VirtualItemView.swift
+++ b/MactrixLibrary/Sources/UI/Timeline/VirtualItemView.swift
@@ -2,6 +2,7 @@ import Models
 import SwiftUI
 
 public struct VirtualItemView: View {
+    @Environment(\.colorScheme) var colorScheme
     let item: VirtualTimelineItem
 
     public init(item: VirtualTimelineItem) {
@@ -40,7 +41,7 @@ public struct VirtualItemView: View {
                 }
                 .frame(height: 40)
                 .padding(.horizontal, 10)
-                .foregroundStyle(.red.mix(with: .black, by: 0.1))
+                .foregroundStyle(.red.mix(with: colorScheme == .light ? .black : .white, by: 0.1))
         case .timelineStart:
             Divider()
                 .overlay {


### PR DESCRIPTION
On Dark Mode, the colour blending for these elements (blended with `.black`) has very low contrast, so this just brings in the `colorScheme` from the `Environment` and uses a ternary to decide to blend with `.white` or `.black`.

<img width="226" height="89" alt="Screenshot 2026-02-09 at 14 59 00" src="https://github.com/user-attachments/assets/d0ec9765-4e9c-4482-a14b-390371ac4a4f" />

vs.

<img width="217" height="80" alt="Screenshot 2026-02-09 at 14 58 09" src="https://github.com/user-attachments/assets/0dbc1dd0-8591-4c5c-af2e-975571d94ec5" />

At some point, it might make sense to move these into the Asset Catalog, but I didn't want to change more than necessary to "fix" this.