### PR TITLE
format notices

### DIFF
--- a/Mactrix/Views/ChatView/ChatMessageView.swift
+++ b/Mactrix/Views/ChatView/ChatMessageView.swift
@@ -76,7 +76,9 @@ struct ChatMessageView: View, UI.MessageEventActions {
             case let .gallery(content: content):
                 Text("Gallery: \(content.body)").textSelection(.enabled)
             case let .notice(content: content):
-                Text("Notice: \(content.body)").textSelection(.enabled)
+                Text(content.body.formatAsMarkdown)
+                    .textSelection(.enabled)
+                    .foregroundColor(.secondary)
             case let .text(content: content):
                 Text(content.body.formatAsMarkdown).textSelection(.enabled)
             case let .location(content: content):


### PR DESCRIPTION
Very simple PR to format notices.

We actually use notices quite a bit with our [maubot](https://github.com/maubot/maubot) instance.

Mactrix now (dark mode):

<img width="565" height="85" alt="image" src="https://github.com/user-attachments/assets/758e89a9-5e6b-4128-ad4e-d69b9ac004b2" />


[my current] Element [theme] for reference:

<img width="832" height="101" alt="image" src="https://github.com/user-attachments/assets/5620ad61-28d3-4d76-a80e-07fbc5fb198d" />
