### PR TITLE
Add forced input focus

### DIFF
--- a/Mactrix/Commands.swift
+++ b/Mactrix/Commands.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct AppCommands: Commands {
     @FocusedValue(WindowState.self) private var windowState: WindowState?
+    @FocusedValue(AppState.self) private var appState: AppState?
     @AppStorage("fontSize") var fontSize: Int = 13
 
     var body: some Commands {
@@ -52,7 +53,7 @@ struct AppCommands: Commands {
         .help("Create a new room")
         .keyboardShortcut("N", modifiers: [.command, .shift])
     }
-    
+
     var fontSizeCommands: some Commands {
         CommandGroup(after: .toolbar) {
             Button {

--- a/Mactrix/MainView.swift
+++ b/Mactrix/MainView.swift
@@ -129,6 +129,7 @@ struct MainView: View {
         .modifier(SearchViewModifier())
         .environment(windowState)
         .focusedSceneValue(windowState)
+        .focusedSceneValue(appState)
     }
 
     func attemptLoadUserSession() async {

--- a/Mactrix/Models/WindowState.swift
+++ b/Mactrix/Models/WindowState.swift
@@ -26,6 +26,8 @@ final class WindowState {
 
     // @SceneStorage("MainView.selectedRoomId")
     var selectedRoomId: String?
+    
+    var shouldFocusInput: Bool = false
 
     // @SceneStorage("MainView.inspectorVisible")
     var inspectorVisible: Bool = false

--- a/Mactrix/Views/ChatView/ChatInputView.swift
+++ b/Mactrix/Views/ChatView/ChatInputView.swift
@@ -8,9 +8,9 @@ struct ChatInputView: View {
     @Binding var replyTo: MatrixRustSDK.EventTimelineItem?
     @Binding var height: CGFloat?
     @AppStorage("fontSize") var fontSize: Int = 13
+    var focusState: FocusState<Bool>.Binding
 
     @State private var chatInput: String = ""
-    @FocusState private var chatFocused: Bool
 
     func sendMessage() {
         guard !chatInput.isEmpty else { return }
@@ -49,7 +49,7 @@ struct ChatInputView: View {
                 }
             }
             TextField("Message room", text: $chatInput, axis: .vertical)
-                .focused($chatFocused)
+                .focused(focusState)
                 .onSubmit { sendMessage() }
                 .textFieldStyle(.plain)
                 .lineLimit(nil)
@@ -76,7 +76,7 @@ struct ChatInputView: View {
         )
         // .shadow(color: .black.opacity(0.1), radius: 4)
         .onTapGesture {
-            chatFocused = true
+            focusState.wrappedValue = true
         }
         .onChange(of: !chatInput.isEmpty) { _, isTyping in
             Task {


### PR DESCRIPTION
closes #5 

- Added state to allow ChatView to attempt to set focus on a room change
- Added a delay to the focus onAppear to deal with races when ChatView is still trying to redraw when it's asked to focus on ChatInputView

Claude was used to create this code. I have tested and reviewed it for my understanding.