### PR TITLE
Update verification request banner

### DIFF
--- a/Mactrix/Models/WindowState.swift
+++ b/Mactrix/Models/WindowState.swift
@@ -32,6 +32,8 @@ final class WindowState {
 
     var inspectorContent: InspectorContent = .roomInfo
 
+    var requestedVerification = false
+    
     var searchQuery: String = ""
     var searchTokens: [SearchToken] = []
     var searchDirectResult: SearchDirectResult?

--- a/Mactrix/Views/MultilineBannerLabelStyle.swift
+++ b/Mactrix/Views/MultilineBannerLabelStyle.swift
@@ -1,0 +1,23 @@
+//
+//  MultilineBanner.swift
+//  Mactrix
+//
+//  Created by Marquis Kurt on 15-02-2026.
+//
+
+import SwiftUI
+
+struct MultilineBannerLabelStyle: LabelStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            configuration.icon
+            VStack(alignment: .leading) {
+                configuration.title
+            }
+        }
+    }
+}
+
+extension LabelStyle where Self == MultilineBannerLabelStyle {
+    static var multiline: MultilineBannerLabelStyle { MultilineBannerLabelStyle() }
+}


### PR DESCRIPTION
When you press Verify session in Mactrix, a request is sent, but there is no visual feedback to the user that the request has been made. To address this, an internal state variable was added to check whether the button was pressed and, when successful, display a progress view indicating that it had sent the request to a user's trusted devices.

The banner label has also been altered to give more information to the user on what to do and why the verification is important.

Fixes #29.