### PR TITLE
avoid trying to copy this byte if Data is empty

### DIFF
--- a/Mactrix/Extensions/Data+Mime.swift
+++ b/Mactrix/Extensions/Data+Mime.swift
@@ -3,6 +3,7 @@ import UniformTypeIdentifiers
 
 extension Data {
     func computeMimeType() -> UTType? {
+        guard !self.isEmpty else { return nil }
         var b: UInt8 = 0
         self.copyBytes(to: &b, count: 1)
 


### PR DESCRIPTION
The `self.copyBytes(to: &b, count: 1)` here sometimes triggers/traps `EXC_BREAKPOINT`.

For me, this was triggering when switching Mactrix to the `#Mactrix` room, on my local build.

This seems to be because there's a failed assertion (or similar) that protects in debug builds. I had a hard time tracking down the actual `copyBytes(to:count:)` source.

The guard here avoids even *trying* to copy the bytes if `Self` (`Data`) is empty.