### PR TITLE
give the content a drawable hover area to improve hover trigger

### DIFF
--- a/MactrixLibrary/Sources/UI/Timeline/MessageEventView.swift
+++ b/MactrixLibrary/Sources/UI/Timeline/MessageEventView.swift
@@ -250,6 +250,7 @@ public struct MessageEventBodyView<
 
             hoverActions
         }
+        .contentShape(Rectangle())
         .onHover { hover in
             hoverText = hover
         }


### PR DESCRIPTION
SwiftUI doesn't seem to trigger a hover event if there's nothing drawn, so "draw" a rectangle as the background.

closes #30