### PR TITLE
Make message hover when hovering over blank space.

### DIFF
--- a/MactrixLibrary/Sources/UI/Timeline/MessageEventView.swift
+++ b/MactrixLibrary/Sources/UI/Timeline/MessageEventView.swift
@@ -76,10 +76,11 @@ struct MessageMainBody<MessageView: View, EventTimelineItem: Models.EventTimelin
             message
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .padding(.vertical, 4.0)
         .background(
             RoundedRectangle(cornerRadius: 4)
                 .fill(focused ? Color.accentColor.opacity(0.1) : Color.gray.opacity(0.1))
-                .opacity(hover || focused ? 1 : 0)
+                .opacity(hover || focused ? 1 : 0.001)
         )
         .padding(.horizontal, 10)
     }


### PR DESCRIPTION
This change addresses the issue that short messages can't be hovered if your cursor is on the "blank" space of the comment.

It also adds a slight padding in order to make mouse movement to the reaction buttons in single-line comments a bit easier.

![Demonstration capture](https://s.pza.sh/a2mUpd0.gif)