### PR TITLE
Re-enable sidebar expandability on macOS 26

### DIFF
--- a/Mactrix/Models/SidebarSectionCollapsibility.swift
+++ b/Mactrix/Models/SidebarSectionCollapsibility.swift
@@ -1,0 +1,33 @@
+//
+//  SidebarSectionCollapsibility.swift
+//  Mactrix
+//
+//  Created by Marquis Kurt on 17-02-2026.
+//
+
+/// A structure that describes the collapsed/expanded states of sections in the sidebar.
+///
+/// This is typically used in conjunction with `Section(_:isExpanded)` to allow users to expand or collapse sidebar
+/// content. Each sidebar entry should have a corresponding entry in this structure.
+///
+/// ```swift
+/// @Environment(WindowState.self) var windowState
+///
+/// Section("Favorites", isExpanded: $windowState.sidebarSections.favorites) { ... }
+/// ```
+///
+/// > Note: You do not need to create this structure yourself. Rather, you should use the collapsibility information
+/// > from ``WindowState/sidebarSections``.
+struct SidebarSectionCollapsibility: Codable, Equatable {
+    /// Whether the favorites section is expanded.
+    var favorites = true
+
+    /// Whether the direct messages section is expanded.
+    var directs = true
+
+    /// Whether the rooms section is expanded.
+    var rooms = true
+
+    /// Whether the spaces section is expanded.
+    var spaces = true
+}

--- a/Mactrix/Models/WindowState.swift
+++ b/Mactrix/Models/WindowState.swift
@@ -38,6 +38,9 @@ final class WindowState {
     var searchTokens: [SearchToken] = []
     var searchDirectResult: SearchDirectResult?
 
+    /// The collapsed/expanded states of the sections in the sidebar.
+    var sidebarSections = SidebarSectionCollapsibility()
+
     var searchFocused: Binding<Bool> {
         Binding(
             get: { self.inspectorContent == .search },

--- a/Mactrix/Views/Sidebar/SidebarView.swift
+++ b/Mactrix/Views/Sidebar/SidebarView.swift
@@ -45,7 +45,7 @@ struct SidebarView: View {
             SessionVerificationStatusView()
 
             if !favorites.isEmpty {
-                Section("Favorites") {
+                Section("Favorites", isExpanded: $windowState.sidebarSections.favorites) {
                     ForEach(favorites) { room in
                         UI.RoomRow(
                             title: room.room.displayName() ?? "Unknown room",
@@ -61,7 +61,7 @@ struct SidebarView: View {
                 }
             }
 
-            Section("Directs") {
+            Section("Directs", isExpanded: $windowState.sidebarSections.directs) {
                 ForEach(directs) { room in
                     UI.RoomRow(
                         title: room.room.displayName() ?? "Unknown user",
@@ -76,7 +76,7 @@ struct SidebarView: View {
                 }
             }
 
-            Section("Rooms") {
+            Section("Rooms", isExpanded: $windowState.sidebarSections.rooms) {
                 ForEach(rooms) { room in
                     UI.RoomRow(
                         title: room.room.displayName() ?? "Unknown Room",
@@ -91,7 +91,7 @@ struct SidebarView: View {
                 }
             }
 
-            Section("Spaces") {
+            Section("Spaces", isExpanded: $windowState.sidebarSections.spaces) {
                 ForEach(spaces) { space in
                     SpaceDisclosureGroup(space: space)
                 }


### PR DESCRIPTION
The behavior for sidebar expandability/collapsibility changed in macOS 26, where the default behavior is to assume that sections cannot be collapsed. To accommodate for this, a different section initializer has been used in which the expanded state can be controlled through a variable. This should also back-deploy all the way back to macOS 14.0 Sonoma.