### PR TITLE
Fix image EXIF orientation not being applied on macOS

### DIFF
--- a/Mactrix/Extensions/Data+Mime.swift
+++ b/Mactrix/Extensions/Data+Mime.swift
@@ -1,4 +1,7 @@
+import CoreImage
 import Foundation
+import ImageIO
+import SwiftUI
 import UniformTypeIdentifiers
 
 extension Data {
@@ -23,5 +26,30 @@ extension Data {
         default:
             return nil
         }
+    }
+
+    /// Decode image data into a SwiftUI Image, applying EXIF orientation.
+    /// `Image(importing:contentType:)` on macOS does not apply EXIF orientation,
+    /// so we route through CIImage which handles it correctly.
+    struct ImageDecodeError: Error {}
+
+    func toOrientedImage(contentType: UTType? = nil) throws -> Image {
+        guard
+            let source = CGImageSourceCreateWithData(self as CFData, nil),
+            let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil)
+        else {
+            throw ImageDecodeError()
+        }
+
+        let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any]
+        let rawOrientation = props?[kCGImagePropertyOrientation as String] as? UInt32
+            ?? CGImagePropertyOrientation.up.rawValue
+        let orientation = CGImagePropertyOrientation(rawValue: rawOrientation) ?? .up
+
+        let ciImage = CIImage(cgImage: cgImage).oriented(orientation)
+        let rep = NSCIImageRep(ciImage: ciImage)
+        let nsImage = NSImage(size: rep.size)
+        nsImage.addRepresentation(rep)
+        return Image(nsImage: nsImage)
     }
 }

--- a/Mactrix/Models/MatrixClient.swift
+++ b/Mactrix/Models/MatrixClient.swift
@@ -253,7 +253,7 @@ extension MatrixClient: UI.ImageLoader {
         }
 
         do {
-            return try await Image(importing: imageData, contentType: imageData.computeMimeType())
+            return try imageData.toOrientedImage(contentType: imageData.computeMimeType())
         } catch {
             Logger.matrixClient.error("failed convert matrix media data to Image: \(error) \(imageData)")
             throw error

--- a/Mactrix/Views/ChatView/MessageImageView.swift
+++ b/Mactrix/Views/ChatView/MessageImageView.swift
@@ -89,7 +89,7 @@ struct MessageImageView: View {
             do {
                 let data = try await matrixClient.client.getMediaContent(mediaSource: content.source)
                 imageData = data
-                image = try await Image(importing: data, contentType: contentType)
+                image = try data.toOrientedImage(contentType: contentType)
             } catch {
                 errorMessage = error.localizedDescription
             }


### PR DESCRIPTION
## Problem

Images taken in portrait mode on a phone appear rotated 90° in the timeline. The raw sensor data is stored in landscape orientation, with an EXIF tag instructing viewers to rotate it 90° for correct display.

## Root Cause

`Image(importing:contentType:)` on macOS does not apply EXIF orientation metadata — it renders the raw pixel data as-is. This is a macOS-specific issue; on iOS, `UIImage` applies EXIF orientation automatically.

## Fix

Route image decoding through `CIImage.oriented(_:)`, which reads the EXIF orientation tag from the image metadata and applies the correct rotation/flip transform. The oriented `CIImage` is then wrapped in `NSCIImageRep` → `NSImage` → `Image(nsImage:)` for SwiftUI rendering.

A `toOrientedImage(contentType:)` helper is added to `Data` and used in both image loading paths (`MessageImageView` and `MatrixClient.loadImage`).