### PR TITLE
Fix memory leak: return early on image cache hit in MessageImageView

### DIFF
--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -17,7 +17,7 @@ jobs:
   notarize:
     runs-on: macos-15
     steps:
-      - name: Checkout (for exportOptions.plist)
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set inputs
@@ -56,27 +56,38 @@ jobs:
           security set-key-partition-list \
             -S apple-tool:,apple: -s -k "" build.keychain
 
-      - name: Export archive
+      - name: Show unzipped contents
+        run: find MactrixApp -maxdepth 3 -type f -o -type d | head -30
+
+      - name: Sign app
         run: |
-          xcodebuild -exportArchive \
-            -archivePath "MactrixApp/Mactrix.xcarchive" \
-            -exportPath ./export \
-            -exportOptionsPlist exportOptions.plist
+          codesign --deep --force --verify --verbose \
+            --sign "Developer ID Application: Andrew Beresford (4ZDNN637A8)" \
+            --options runtime \
+            MactrixApp/Mactrix.app
+
+      - name: Create DMG
+        run: |
+          mkdir -p dist
+          hdiutil create -volname Mactrix \
+            -srcfolder MactrixApp/Mactrix.app \
+            -ov -format UDZO \
+            dist/Mactrix.dmg
 
       - name: Notarize
         run: |
-          xcrun notarytool submit ./export/Mactrix.dmg \
+          xcrun notarytool submit dist/Mactrix.dmg \
             --key-id "${{ secrets.APPLE_KEY_ID }}" \
             --key <(echo "${{ secrets.APPLE_KEY_P8 }}") \
             --issuer "${{ secrets.APPLE_ISSUER_ID }}" \
             --wait
 
       - name: Staple
-        run: xcrun stapler staple ./export/Mactrix.dmg
+        run: xcrun stapler staple dist/Mactrix.dmg
 
       - name: Upload notarized artifact
         uses: actions/upload-artifact@v4
         with:
           name: Mactrix-notarized-${{ steps.inputs.outputs.tag }}
-          path: ./export/Mactrix.dmg
+          path: dist/Mactrix.dmg
           retention-days: 14

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -57,7 +57,7 @@ jobs:
             -S apple-tool:,apple: -s -k "" build.keychain
 
       - name: Show unzipped contents
-        run: find MactrixApp -maxdepth 3 -type f -o -type d | head -30
+        run: find MactrixApp -maxdepth 3 | head -30
 
       - name: Sign app
         run: |
@@ -74,11 +74,15 @@ jobs:
             -ov -format UDZO \
             dist/Mactrix.dmg
 
+      - name: Write notarization key
+        run: |
+          echo "${{ secrets.APPLE_KEY_P8 }}" > /tmp/notarize_key.p8
+
       - name: Notarize
         run: |
           xcrun notarytool submit dist/Mactrix.dmg \
             --key-id "${{ secrets.APPLE_KEY_ID }}" \
-            --key <(echo "${{ secrets.APPLE_KEY_P8 }}") \
+            --key /tmp/notarize_key.p8 \
             --issuer "${{ secrets.APPLE_ISSUER_ID }}" \
             --wait
 
@@ -91,3 +95,7 @@ jobs:
           name: Mactrix-notarized-${{ steps.inputs.outputs.tag }}
           path: dist/Mactrix.dmg
           retention-days: 14
+
+      - name: Clean up key
+        if: always()
+        run: rm -f /tmp/notarize_key.p8

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set inputs
         id: inputs
@@ -90,7 +90,7 @@ jobs:
         run: xcrun stapler staple dist/Mactrix.dmg
 
       - name: Upload notarized artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Mactrix-notarized-${{ steps.inputs.outputs.tag }}
           path: dist/Mactrix.dmg

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -5,8 +5,8 @@ on:
     types: [notarize]
   workflow_dispatch:
     inputs:
-      run_id:
-        description: "Upstream workflow run ID"
+      tag:
+        description: "Release tag to notarize (e.g. v0.1.0)"
         required: true
       repo:
         description: "Upstream repo (owner/name)"
@@ -24,31 +24,18 @@ jobs:
         id: inputs
         run: |
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            echo "run_id=${{ github.event.client_payload.run_id }}" >> $GITHUB_OUTPUT
+            echo "tag=${{ github.event.client_payload.tag }}" >> $GITHUB_OUTPUT
             echo "repo=${{ github.event.client_payload.repo }}" >> $GITHUB_OUTPUT
           else
-            echo "run_id=${{ inputs.run_id }}" >> $GITHUB_OUTPUT
+            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
             echo "repo=${{ inputs.repo }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Download artifact from upstream
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.UPSTREAM_READ_TOKEN }}
-          script: |
-            const [owner, repo] = '${{ steps.inputs.outputs.repo }}'.split('/');
-            const runId = parseInt('${{ steps.inputs.outputs.run_id }}');
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner, repo, run_id: runId
-            });
-            const artifact = artifacts.data.artifacts.find(a => a.name === 'Mactrix.app');
-            if (!artifact) throw new Error('Mactrix.app artifact not found');
-            const download = await github.rest.actions.downloadArtifact({
-              owner, repo,
-              artifact_id: artifact.id,
-              archive_format: 'zip'
-            });
-            require('fs').writeFileSync('Mactrix.zip', Buffer.from(download.data));
+      - name: Download release asset
+        run: |
+          curl -L \
+            "https://github.com/${{ steps.inputs.outputs.repo }}/releases/download/${{ steps.inputs.outputs.tag }}/Mactrix.app.zip" \
+            -o Mactrix.zip
 
       - name: Unzip artifact
         run: |
@@ -90,6 +77,6 @@ jobs:
       - name: Upload notarized artifact
         uses: actions/upload-artifact@v4
         with:
-          name: Mactrix-notarized
+          name: Mactrix-notarized-${{ steps.inputs.outputs.tag }}
           path: ./export/Mactrix.dmg
           retention-days: 14

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -1,0 +1,95 @@
+name: Notarize
+
+on:
+  repository_dispatch:
+    types: [notarize]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Upstream workflow run ID"
+        required: true
+      repo:
+        description: "Upstream repo (owner/name)"
+        required: true
+        default: "viktorstrate/mactrix"
+
+jobs:
+  notarize:
+    runs-on: macos-15
+    steps:
+      - name: Checkout (for exportOptions.plist)
+        uses: actions/checkout@v4
+
+      - name: Set inputs
+        id: inputs
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            echo "run_id=${{ github.event.client_payload.run_id }}" >> $GITHUB_OUTPUT
+            echo "repo=${{ github.event.client_payload.repo }}" >> $GITHUB_OUTPUT
+          else
+            echo "run_id=${{ inputs.run_id }}" >> $GITHUB_OUTPUT
+            echo "repo=${{ inputs.repo }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download artifact from upstream
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.UPSTREAM_READ_TOKEN }}
+          script: |
+            const [owner, repo] = '${{ steps.inputs.outputs.repo }}'.split('/');
+            const runId = parseInt('${{ steps.inputs.outputs.run_id }}');
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner, repo, run_id: runId
+            });
+            const artifact = artifacts.data.artifacts.find(a => a.name === 'Mactrix.app');
+            if (!artifact) throw new Error('Mactrix.app artifact not found');
+            const download = await github.rest.actions.downloadArtifact({
+              owner, repo,
+              artifact_id: artifact.id,
+              archive_format: 'zip'
+            });
+            require('fs').writeFileSync('Mactrix.zip', Buffer.from(download.data));
+
+      - name: Unzip artifact
+        run: |
+          mkdir -p MactrixApp
+          unzip Mactrix.zip -d MactrixApp
+
+      - name: Import signing certificate
+        run: |
+          echo "${{ secrets.APPLE_CERTIFICATE_P12 }}" | base64 --decode > certificate.p12
+          security create-keychain -p "" build.keychain
+          security import certificate.p12 \
+            -k build.keychain \
+            -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" \
+            -T /usr/bin/codesign
+          security list-keychains -s build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+          security set-key-partition-list \
+            -S apple-tool:,apple: -s -k "" build.keychain
+
+      - name: Export archive
+        run: |
+          xcodebuild -exportArchive \
+            -archivePath "MactrixApp/Mactrix.xcarchive" \
+            -exportPath ./export \
+            -exportOptionsPlist exportOptions.plist
+
+      - name: Notarize
+        run: |
+          xcrun notarytool submit ./export/Mactrix.dmg \
+            --key-id "${{ secrets.APPLE_KEY_ID }}" \
+            --key <(echo "${{ secrets.APPLE_KEY_P8 }}") \
+            --issuer "${{ secrets.APPLE_ISSUER_ID }}" \
+            --wait
+
+      - name: Staple
+        run: xcrun stapler staple ./export/Mactrix.dmg
+
+      - name: Upload notarized artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Mactrix-notarized
+          path: ./export/Mactrix.dmg
+          retention-days: 14

--- a/Mactrix/Views/ChatView/MessageImageView.swift
+++ b/Mactrix/Views/ChatView/MessageImageView.swift
@@ -96,6 +96,7 @@ struct MessageImageView: View {
             let cacheKey = NSString(string: content.source.url())
             if let cached = MatrixClient.imageCache.object(forKey: cacheKey) {
                 image = Image(nsImage: cached)
+                return
             }
 
             do {

--- a/NOTARIZATION.md
+++ b/NOTARIZATION.md
@@ -1,0 +1,76 @@
+# macOS Notarization
+
+This fork maintains an automated notarization workflow for Mactrix releases. When triggered, it downloads the release asset from [viktorstrate/mactrix](https://github.com/viktorstrate/mactrix), signs it with an Apple Developer ID certificate, notarizes it with Apple, and uploads the result as a build artifact.
+
+## Example: v0.1.0
+
+The v0.1.0 release has been notarized as a proof of concept. The notarized DMG is available as a build artifact from the [Notarize workflow](https://github.com/beezly/mactrix/actions/workflows/notarize.yml) — download `Mactrix-notarized-v0.1.0.dmg` from the latest successful run.
+
+This DMG is signed with **Developer ID Application: Andrew Beresford (4ZDNN637A8)** and will install on macOS without any Gatekeeper warnings.
+
+## How it works
+
+1. The workflow downloads `Mactrix.app.zip` from the upstream release
+2. Signs the `.app` with a Developer ID Application certificate
+3. Packages it into a DMG
+4. Submits the DMG to Apple's notarization service
+5. Staples the notarization ticket to the DMG
+6. Uploads the result as a GitHub Actions artifact (retained for 14 days)
+
+## Triggering automatically on new releases
+
+To have notarization run automatically whenever a new release is published in `viktorstrate/mactrix`, two things are needed:
+
+### 1. Add a secret to viktorstrate/mactrix
+
+In the upstream repo: **Settings → Secrets and variables → Actions → New repository secret**
+
+- **Name:** `NOTARIZE_DISPATCH_TOKEN`
+- **Value:** *(provided separately — a fine-grained PAT scoped to Actions: write on beezly/mactrix only)*
+
+### 2. Add a workflow file to viktorstrate/mactrix
+
+Create `.github/workflows/notify-notarize.yml`:
+
+```yaml
+name: Trigger notarization
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger notarization in beezly/mactrix
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.NOTARIZE_DISPATCH_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/beezly/mactrix/dispatches \
+            -d "{\"event_type\":\"notarize\",\"client_payload\":{\"tag\":\"${{ github.event.release.tag_name }}\",\"repo\":\"viktorstrate/mactrix\"}}"
+```
+
+When a release is published, this sends a `repository_dispatch` event to this fork with the release tag, which triggers the notarize workflow automatically.
+
+## Triggering manually
+
+The workflow can also be triggered manually via **Actions → Notarize → Run workflow**, with:
+
+- **tag** — the release tag to notarize (e.g. `v0.1.0`)
+- **repo** — the upstream repo (default: `viktorstrate/mactrix`)
+
+## Credentials
+
+All Apple credentials are stored as secrets in this repository and never touch the upstream repo:
+
+| Secret | Description |
+|--------|-------------|
+| `APPLE_CERTIFICATE_P12` | Base64-encoded Developer ID Application certificate |
+| `APPLE_CERTIFICATE_PASSWORD` | Password for the .p12 export |
+| `APPLE_KEY_ID` | App Store Connect API key ID |
+| `APPLE_KEY_P8` | App Store Connect API private key (.p8) |
+| `APPLE_ISSUER_ID` | App Store Connect issuer UUID |
+
+The `NOTARIZE_DISPATCH_TOKEN` held by the upstream repo is a fine-grained PAT with **Actions: write** permission scoped to this fork only — it cannot read or modify any code or secrets.

--- a/exportOptions.plist
+++ b/exportOptions.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>developer-id</string>
+    <key>teamID</key>
+    <string>4ZDNN637A8</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>signingCertificate</key>
+    <string>Developer ID Application</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- `MessageImageView`'s `.task` block checked `NSCache` on cache hit but never returned, causing `getMediaContent` to be called on every channel visit even for already-cached images
- Adds the missing `return` after a cache hit — a one-line fix matching the pattern already used in `MatrixImageView` and `AvatarImage`
- Verified with `OSLog` debug instrumentation: before the fix, every return to a channel showed `cache HIT` immediately followed by a redundant network fetch; after the fix, cache hits return early with no network call

## Test plan

- [ ] Navigate to a channel with images and note memory usage
- [ ] Switch to another channel and back — memory should no longer increase for already-loaded images
- [ ] First load of an image still fetches from network (cache miss path unchanged)

Fixes #89