### PR TITLE
Add memory limits to image NSCache

### DIFF
--- a/Mactrix/Models/MatrixClient.swift
+++ b/Mactrix/Models/MatrixClient.swift
@@ -240,7 +240,25 @@ extension MatrixClient: MatrixRustSDK.ClientSessionDelegate {
 }
 
 extension MatrixClient: UI.ImageLoader {
-    static let imageCache = NSCache<NSString, NSImage>()
+    // In-memory cache of decoded NSImage objects. Purpose is rendering performance —
+    // keeping decoded bitmaps ready to display prevents flicker when scrolling back to
+    // previously viewed images. This is distinct from the SDK-level media download cache
+    // (see clearCaches / getMediaFile(useCache:)) which avoids re-fetching from the server.
+    // Costs are tracked in decoded RGBA bytes (width × height × 4), not compressed sizes,
+    // since a typical JPEG can be 20-50× larger once decoded.
+    static let imageCache: NSCache<NSString, NSImage> = {
+        let cache = NSCache<NSString, NSImage>()
+        cache.totalCostLimit = 256 * 1024 * 1024  // 256MB decoded pixels
+        return cache
+    }()
+
+    private static let imageCacheMaxObjectCost = 64 * 1024 * 1024  // 64MB per object (~8000x2000px RGBA)
+
+    static func setCachedImage(_ image: NSImage, forKey key: NSString) {
+        let cost = Int(image.size.width * image.size.height) * 4  // decoded RGBA bytes
+        guard cost <= imageCacheMaxObjectCost else { return }
+        imageCache.setObject(image, forKey: key, cost: cost)
+    }
 
     func cachedImage(matrixUrl: String) -> Image? {
         guard let nsImage = Self.imageCache.object(forKey: NSString(string: matrixUrl)) else { return nil }
@@ -270,7 +288,7 @@ extension MatrixClient: UI.ImageLoader {
 
         do {
             let nsImage = try imageData.toOrientedImage(contentType: imageData.computeMimeType())
-            Self.imageCache.setObject(nsImage, forKey: cacheKey, cost: imageData.count)
+            Self.setCachedImage(nsImage, forKey: cacheKey)
             return Image(nsImage: nsImage)
         } catch {
             Logger.matrixClient.error("failed convert matrix media data to Image: \(error) \(imageData)")

--- a/Mactrix/Views/ChatView/MessageImageView.swift
+++ b/Mactrix/Views/ChatView/MessageImageView.swift
@@ -102,7 +102,7 @@ struct MessageImageView: View {
                 let data = try await matrixClient.client.getMediaContent(mediaSource: content.source)
                 imageData = data
                 let nsImage = try data.toOrientedImage(contentType: contentType)
-                MatrixClient.imageCache.setObject(nsImage, forKey: cacheKey, cost: data.count)
+                MatrixClient.setCachedImage(nsImage, forKey: cacheKey)
                 image = Image(nsImage: nsImage)
             } catch {
                 errorMessage = error.localizedDescription

--- a/Mactrix/Views/MatrixImageView.swift
+++ b/Mactrix/Views/MatrixImageView.swift
@@ -60,7 +60,7 @@ struct MatrixImageView: View {
                     let contentType = mimeType.flatMap { UTType(mimeType: $0) }
                     image = try await Image(importing: data, contentType: contentType)
                     if let nsImage = NSImage(data: data) {
-                        MatrixClient.imageCache.setObject(nsImage, forKey: cacheKey, cost: data.count)
+                        MatrixClient.setCachedImage(nsImage, forKey: cacheKey)
                     }
                 } catch {
                     errorMessage = error.localizedDescription


### PR DESCRIPTION
## Summary

- Sets a **256MB `totalCostLimit`** on `MatrixClient.imageCache`
- Adds a **64MB per-object limit** — images larger than 64MB decoded are not cached (they still load and display, but won't evict smaller cached images)
- **Fixes cost calculation**: costs are now computed from decoded RGBA pixel size (`width × height × 4 bytes`) rather than the compressed download size. Compressed sizes underestimate real memory usage by 20-50× for typical JPEGs — a 500KB JPEG can easily decode to 24MB — so the previous `totalCostLimit` was not bounding memory meaningfully
- Introduces a `setCachedImage(_:forKey:)` helper on `MatrixClient` so cost calculation and the per-object guard are enforced in one place; all three previous `imageCache.setObject(...)` call sites now route through it

## Test plan

- [ ] Navigate through channels with many images — memory usage should stabilise around 256MB of decoded image data rather than growing unboundedly
- [ ] Very large images (>64MB decoded, e.g. a ~16MP photo) still load and display correctly, they just re-download on revisit
- [ ] Normal images are served from cache on channel revisit

Closes #94