### PR TITLE
Fix memory leak: use weak self in timeline observation loop

### DIFF
--- a/Mactrix/Views/ChatView/TimelineView/TimelineTableView.swift
+++ b/Mactrix/Views/ChatView/TimelineView/TimelineTableView.swift
@@ -206,8 +206,8 @@ class TimelineViewController: NSViewController {
 
         let focusedTimelineEventId = withObservationTracking {
             timeline.focusedTimelineEventId
-        } onChange: {
-            Task { @MainActor in self.listenForFocusTimelineItem() }
+        } onChange: { [weak self] in
+            Task { @MainActor in self?.listenForFocusTimelineItem() }
         }
 
         guard let focusedTimelineEventId,


### PR DESCRIPTION
## Summary

- `TimelineViewController.listenForFocusTimelineItem()` uses `withObservationTracking` with a recursive `onChange` closure to watch for focused event changes. The closure captured `self` strongly, meaning the observation system held the `TimelineViewController` alive indefinitely — even after switching rooms. Since `TimelineViewController` holds `LiveTimeline` which holds `LiveRoom`, the entire timeline object graph accumulated with each room switch.
- Fix: capture `[weak self]` in the `onChange` closure so the observation chain breaks when the view controller is deallocated.

Relates to #89

## Verification with `heap`

You can verify the fix using the `heap` command-line tool. Get the PID of the running app with `pgrep -x Mactrix` or from Activity Monitor, then:

1. Open the app, select a room, run `heap <pid> | grep -E 'LiveTimeline|LiveRoom'` — should show 1 of each
2. Switch between ~20 rooms
3. Run the same `heap` command again — without the fix the counts match the number of room switches; with the fix they stay at 1