### PR TITLE
switch message from text field to text view

### DIFF
--- a/MactrixLibrary/Sources/MessageFormatting/AttributedTextView.swift
+++ b/MactrixLibrary/Sources/MessageFormatting/AttributedTextView.swift
@@ -37,11 +37,13 @@ public struct AttributedTextView: NSViewRepresentable {
         guard let layoutManager = textView.layoutManager,
               let textContainer = textView.textContainer else { return nil }
 
+        let savedSize = textContainer.size
         textContainer.size = CGSize(width: width, height: .greatestFiniteMagnitude)
         layoutManager.ensureLayout(for: textContainer)
-
         let rect = layoutManager.usedRect(for: textContainer)
-        return CGSize(width: ceil(rect.width), height: ceil(rect.height))
+        textContainer.size = savedSize
+
+        return CGSize(width: width, height: ceil(rect.height))
     }
 }
 

--- a/MactrixLibrary/Sources/MessageFormatting/AttributedTextView.swift
+++ b/MactrixLibrary/Sources/MessageFormatting/AttributedTextView.swift
@@ -7,35 +7,41 @@ public struct AttributedTextView: NSViewRepresentable {
         self.attributedString = attributedString.trimmed
     }
 
-    public func makeNSView(context: Context) -> NSTextField {
-        let textField = NSTextField(labelWithAttributedString: attributedString)
+    public func makeNSView(context: Context) -> NSTextView {
+        let textView = NSTextView()
 
-        textField.isEditable = false
-        textField.isSelectable = true
-        textField.allowsEditingTextAttributes = true
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+        textView.focusRingType = .none
 
-        textField.lineBreakStrategy = .standard
-        textField.lineBreakMode = .byWordWrapping
-        textField.usesSingleLineMode = false
+        textView.textContainerInset = .zero
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.widthTracksTextView = true
+        textView.isVerticallyResizable = false
+        textView.isHorizontallyResizable = false
 
-        return textField
+        textView.textStorage?.setAttributedString(attributedString)
+
+        return textView
     }
 
-    public func updateNSView(_ textField: NSTextField, context: Context) {
-        if textField.attributedStringValue != attributedString {
-            textField.attributedStringValue = attributedString
+    public func updateNSView(_ textView: NSTextView, context: Context) {
+        if textView.attributedString() != attributedString {
+            textView.textStorage?.setAttributedString(attributedString)
         }
     }
 
-    public func sizeThatFits(_ proposal: ProposedViewSize, nsView textField: NSTextField, context: Context) -> CGSize? {
+    public func sizeThatFits(_ proposal: ProposedViewSize, nsView textView: NSTextView, context: Context) -> CGSize? {
         guard let width = proposal.width, width > 0, width != .infinity else { return nil }
+        guard let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer else { return nil }
 
-        textField.preferredMaxLayoutWidth = width
-        guard let size = textField.cell?.cellSize(forBounds: NSRect(x: 0, y: 0, width: width, height: CGFloat.greatestFiniteMagnitude)) else {
-            return nil
-        }
-        
-        return CGSize(width: ceil(size.width), height: ceil(size.height))
+        textContainer.size = CGSize(width: width, height: .greatestFiniteMagnitude)
+        layoutManager.ensureLayout(for: textContainer)
+
+        let rect = layoutManager.usedRect(for: textContainer)
+        return CGSize(width: ceil(rect.width), height: ceil(rect.height))
     }
 }
 

--- a/MactrixLibrary/Sources/MessageFormatting/Parser.swift
+++ b/MactrixLibrary/Sources/MessageFormatting/Parser.swift
@@ -11,7 +11,7 @@ public func parseFormattedBody(_ body: String, baseFontSize: CGFloat = 13) -> NS
 
     let parser = ZHTMLParserBuilder
         .initWithDefault()
-        .set(rootStyle: MarkupStyle(font: MarkupStyleFont(size: baseFontSize)))
+        .set(rootStyle: MarkupStyle(font: MarkupStyleFont(size: baseFontSize), foregroundColor: MarkupStyleColor(color: NSColor.labelColor)))
         .add(
             H1_HTMLTagName(),
             withCustomStyle: MarkupStyle(


### PR DESCRIPTION
to handle the weird 'activated' mode that was changing colour

This was making the text the wrong colour after clicking (see #103; closes #103).

I mostly only know SwiftUI, so this may be entirely the wrong path here—definitely open to review and suggestions—but this does fix the poor behaviour I experienced.