### PR TITLE
docs: update minimum macOS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Mactrix is currently in early development, which means that distribution with au
 
 ### Requirements
 
-- macOS 15 or later
+- macOS 15.7 or later
 - Up-to-date Xcode installed
 
 Xcode will automatically download all dependencies when building the project for the first time.


### PR DESCRIPTION
## Summary
- update the README build requirement from macOS 15 to macOS 15.7
- match the app target's `MACOSX_DEPLOYMENT_TARGET` in `Mactrix.xcodeproj`

## Validation
- `rg -n "macOS 15(\\.7)? or later|MACOSX_DEPLOYMENT_TARGET" README.md Mactrix.xcodeproj/project.pbxproj`
- `git diff --check`

I also tried `xcodebuild -showBuildSettings -project Mactrix.xcodeproj -scheme Mactrix`, but local Xcode validation did not complete because CoreSimulator is older than the installed Xcode build.

Fixes #88.
